### PR TITLE
chore: Add pre-commit hooks to run CI locally

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,40 @@
+fail_fast: true
+repos:
+  - repo: local
+    hooks:
+      - id: format
+        name: Run cargo format
+        entry: cargo +nightly fmt --check
+        language: system
+        pass_filenames: false
+        stages: [commit, push, manual]
+      - id: clippy
+        name: Run cargo clippy
+        entry: cargo clippy --no-deps --all-targets
+        language: system
+        pass_filenames: false
+        stages: [commit, push, manual]
+      - id: nextest
+        name: Run cargo nextest
+        entry: cargo nextest run --fail-fast
+        language: system
+        pass_filenames: false
+        stages: [push, manual]
+      - id: doc
+        name: Run cargo doc
+        entry: bash -c 'env RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps --document-private-items'
+        language: system
+        pass_filenames: false
+        stages: [push, manual]
+      - id: build
+        name: Run cargo build
+        entry: cargo +nightly build --target=wasm32-unknown-unknown --workspace --release --no-default-features
+        language: system
+        pass_filenames: false
+        stages: [push, manual]
+  - repo: https://github.com/alessandrojcm/commitlint-pre-commit-hook
+    rev: v8.0.0
+    hooks:
+      - id: commitlint
+        stages: [commit-msg]
+        additional_dependencies: ["@commitlint/config-conventional"]


### PR DESCRIPTION
This `pre-commit-config` tries to simulate locally all the checks that
are run in the already configured CI, avoiding pushing code all the time
to the remote server to only then make sure if the code is working or
not. This change, however, is not meant to replace the checks done at
CI, its sole purpose is to help developers in their workflow process.
The final word when it comes to approving code changes or not is only
through the CI.