### PR TITLE
chore(CI): run cargo-check to WASM target

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,7 +97,7 @@ jobs:
           args: --workspace --no-deps --document-private-items
 
   build:
-    name: Run cargo build
+    name: Check WASM compilation
     needs: [format, clippy, test, doc]
     runs-on: ubuntu-latest
     env:
@@ -116,5 +116,5 @@ jobs:
       - uses: Swatinem/rust-cache@v2
       - uses: actions-rs/cargo@v1
         with:
-          command: build
-          args: --workspace --release --no-default-features --target=wasm32-unknown-unknown
+          command: check
+          args: --workspace --no-default-features --target=wasm32-unknown-unknown

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -27,8 +27,8 @@ repos:
         pass_filenames: false
         stages: [push, manual]
       - id: build
-        name: Run cargo build
-        entry: cargo +nightly build --target=wasm32-unknown-unknown --workspace --release --no-default-features
+        name: Check WASM compilation
+        entry: cargo +nightly check --target=wasm32-unknown-unknown --workspace --no-default-features
         language: system
         pass_filenames: false
         stages: [push, manual]


### PR DESCRIPTION
Following an internal discussion on how to speed up the CI and pre-commit hooks, this implements the use of `cargo check` instead of `cargo build` to verify that all libraries compile to WASM (with no default features).

https://doc.rust-lang.org/cargo/commands/cargo-check.html
