### PR TITLE
chore(CI): Update nextest status level

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,7 +60,7 @@ jobs:
       CARGO_TERM_COLOR: always
       NEXTEST_FAILURE_OUTPUT: final
       NEXTEST_SUCCESS_OUTPUT: never
-      NEXTEST_STATUS_LEVEL: fail
+      NEXTEST_STATUS_LEVEL: all
     steps:
       - uses: actions/checkout@v3
       - uses: actions-rs/toolchain@v1


### PR DESCRIPTION
Very simple change, only to provide more information when reading CI logs for `nextest` runs.